### PR TITLE
Invert the styling of the active vs. inactive tabs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const backgroundColor = '#fdf6e3'
 const foregroundColor = '#839496'
-const cursorColor = 'rgba(211, 54, 130, 0.6)
+const cursorColor = 'rgba(211, 54, 130, 0.6)'
 const borderColor = 'rgba(38, 139, 210, 0.3)' // blue
 const activeTabBorderColor = '#6c71c4' // cyan
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,6 @@ exports.decorateConfig = config => {
       * {
         -webkit-font-feature-settings: "liga" on, "calt" on, "dlig" on !important;
         text-rendering: optimizeLegibility !important;
-        font-weight: 500;
       }
       .cursor-node {
         width: .325rem !important;

--- a/index.js
+++ b/index.js
@@ -51,21 +51,22 @@ exports.decorateConfig = config => {
         border-color: transparent !important;
       }
       .tab_tab {
+        border: transparent !important;
         color: ${foregroundColor} !important;
-        background-color: ${backgroundColor};
+        background-color: #e6dfcb;
+        border-bottom: solid 3px ${activeTabBorderColor} !important;
       }
       .tabs_title {
         color: ${foregroundColor} !important;
       }
-      .active_1gcgehd:before {
+      .tab_tab.tab_active:before {
         border-bottom: transparent !important;
       }
       .tab_tab.tab_active {
-        border: transparent !important;
-        font-weight: bold;
         color: ${foregroundColor} !important;
-        background-color: #e6dfcb;
-        border-bottom: solid 3px ${activeTabBorderColor} !important;
+        background-color: ${backgroundColor};
+        border-bottom: none !important;
+        font-weight: bold;
       }
     `
   })


### PR DESCRIPTION
Throwing this one out there in case you're interested:

I didn't like having the active tab be the "dimmer" colored
tab. Instead, non-active tabs should be dim, and the active
one should be the same color as the terminal.

Also fixed the synax error.
