### PR TITLE
Increase contrast between foreground / medium grey

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const colors = [
   '#6c71c4', // violet
   '#2aa198', // cyan
   '#657b83', // light gray
-  '#586e75', // medium gray
+  '#a3b7bd', // medium gray
   '#dc322f', // red
   '#859900', // green
   '#b58900', // yellow
@@ -88,4 +88,3 @@ exports.decorateConfig = config => {
     `
   })
 }
-


### PR DESCRIPTION
This theme is awesome 🎊 🌟 , my favourite of choice when using **Hyper**.

However, because the foreground colour `#839496` is lighter than the medium gray colour `#657b83`, it's hard to use it along an auto-suggest plugin in your shell:

![screen shot 2017-11-30 at 12 13 46](https://user-images.githubusercontent.com/5938217/33431244-6e79bf5a-d5cb-11e7-8dee-b0d3062f35f6.png)

I suggest using a new medium gray colour `#a3b7bd` lighter than the foreground colour `#839496`.